### PR TITLE
fix: move FINAL modifier to the right place

### DIFF
--- a/ch/query_select.go
+++ b/ch/query_select.go
@@ -325,6 +325,9 @@ func (q *SelectQuery) appendQuery(
 			return nil, err
 		}
 	}
+	if q.final {
+		b = append(b, " FINAL"...)
+	}
 	if !q.sample.IsZero() {
 		b = append(b, " SAMPLE "...)
 		b, err = q.sample.AppendQuery(fmter, b)
@@ -395,9 +398,6 @@ func (q *SelectQuery) appendQuery(
 		if q.offset > 0 {
 			b = append(b, " OFFSET "...)
 			b = strconv.AppendInt(b, int64(q.offset), 10)
-		}
-		if q.final {
-			b = append(b, " FINAL"...)
 		}
 	} else if cteCount {
 		b = append(b, `) SELECT `...)

--- a/ch/query_test.go
+++ b/ch/query_test.go
@@ -96,6 +96,25 @@ func TestQuery(t *testing.T) {
 				GroupExpr("group2, group3").
 				OrderExpr("order2, order3")
 		},
+		func(db *ch.DB) chschema.QueryAppender {
+			return db.NewSelect().
+				Model((*Model)(nil)).
+				Final()
+		},
+		func(db *ch.DB) chschema.QueryAppender {
+			return db.NewSelect().
+				Model((*Model)(nil)).
+				Where("id = ?", 1).
+				Final()
+		},
+		func(db *ch.DB) chschema.QueryAppender {
+			return db.NewSelect().
+				Model((*Model)(nil)).
+				Where("id = ?", 1).
+				Final().
+				Group("id").
+				OrderExpr("id")
+		},
 	}
 
 	db := chDB()

--- a/ch/testdata/snapshots/TestQuery-14
+++ b/ch/testdata/snapshots/TestQuery-14
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."string", "model"."bytes" FROM "models" AS "model" FINAL

--- a/ch/testdata/snapshots/TestQuery-15
+++ b/ch/testdata/snapshots/TestQuery-15
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."string", "model"."bytes" FROM "models" AS "model" FINAL WHERE (id = 1)

--- a/ch/testdata/snapshots/TestQuery-16
+++ b/ch/testdata/snapshots/TestQuery-16
@@ -1,0 +1,1 @@
+SELECT "model"."id", "model"."string", "model"."bytes" FROM "models" AS "model" FINAL WHERE (id = 1) GROUP BY "id" ORDER BY id


### PR DESCRIPTION
The documentation (http://devdoc.net/database/ClickhouseDocs_19.4.1.3-docs/query_language/select/) says FINAL has to be placed right after the table name, before SAMPLE:
  SELECT [DISTINCT] expr_list
    [FROM [db.]table | (subquery) | table_function] [FINAL]
    [SAMPLE sample_coeff]

At the moment it's appended to the end of the query which results in invalid queries being generated when there are WHERE, ORDER BY or any other clauses used.