### PR TITLE
fix: Update column.go

### DIFF
--- a/ch/chschema/column.go
+++ b/ch/chschema/column.go
@@ -142,6 +142,8 @@ func (c NumericColumnOf[T]) ConvertAssign(idx int, v reflect.Value) error {
 
 func (c BoolColumn) ConvertAssign(idx int, v reflect.Value) error {
 	switch v.Kind() {
+	case reflect.Ptr:
+		v.Set(reflect.ValueOf(&c.Column[idx]))
 	case reflect.Bool:
 		v.SetBool(c.Column[idx])
 	default:


### PR DESCRIPTION
Convert ptr to bool.

For example , we have a struct
```go
type Test struct {
	ch.CHModel     `ch:"partition:toYYYYMM(time)"`
	IsActive     *bool      `ch:"is_active"`
}

```

If I am trying scan `err := r.db.NewSelect().Model(&result).Limit(1).Scan(ctx)`
i got error: 
```
 github.com/uptrace/go-clickhouse/ch/chschema.BoolColumn.ConvertAssign({{{0x140000b28c0?, 0x100f62714?, 0x101536540?}}}, 0x1400046ddd0?, {0x1014277e0?, 0x1400046de40?, 0x1400048a7d8?})
        	/.../vendor/github.com/uptrace/go-clickhouse/ch/chschema/column.go:148 +0xd8
        github.com/uptrace/go-clickhouse/ch.scanRow(0x140000a60a0, 0x14000199340, {0x101536540?, 0x1400046ddd0?, 0x14000524300?}, 0x10156b200?, 0x0)
        	/.../vendor/github.com/uptrace/go-clickhouse/ch/model_table_struct.go:79 +0x10c
        github.com/uptrace/go-clickhouse/ch.(*structTableModel).ScanBlock(0x14000524300?, 0x10156b200?)
        	/.../vendor/github.com/uptrace/go-clickhouse/ch/model_table_struct.go:60 +0x7c
```