### PR TITLE
fix: parse datetime64 precision with timezone

### DIFF
--- a/ch/chschema/types.go
+++ b/ch/chschema/types.go
@@ -346,6 +346,16 @@ func parseDateTime64Prec(s string) int {
 	if s == "" {
 		return 0
 	}
+
+	// DateTime64 type definitions syntax is
+	// DateTime64(precision, [timezone])
+	// So we need to split by comma and take the first part
+	// to get the precision.
+	// Examples:
+	// DateTime64(3, 'Asia/Bangkok')
+	// DateTime64(3)
+	s = strings.Split(s, ",")[0]
+
 	prec, err := strconv.Atoi(s)
 	if err != nil {
 		return 0

--- a/ch/chschema/types.go
+++ b/ch/chschema/types.go
@@ -347,13 +347,10 @@ func parseDateTime64Prec(s string) int {
 		return 0
 	}
 
-	// DateTime64 type definitions syntax is
-	// DateTime64(precision, [timezone])
-	// So we need to split by comma and take the first part
-	// to get the precision.
-	// Examples:
+	// DateTime64 can have timezone, e.g.:
 	// DateTime64(3, 'Asia/Bangkok')
 	// DateTime64(3)
+	// we need to remove timezone to get precision
 	s = strings.Split(s, ",")[0]
 
 	prec, err := strconv.Atoi(s)

--- a/ch/db_test.go
+++ b/ch/db_test.go
@@ -267,7 +267,8 @@ func TestScanArrayUint8(t *testing.T) {
 
 func TestDateTime64(t *testing.T) {
 	type Model struct {
-		Time time.Time `ch:"type:DateTime64(9)"`
+		Time       time.Time `ch:"type:DateTime64(9)"`
+		TimeWithTZ time.Time `ch:"type:DateTime64(9, 'UTC')"`
 	}
 
 	ctx := context.Background()
@@ -278,7 +279,10 @@ func TestDateTime64(t *testing.T) {
 	err := db.ResetModel(ctx, (*Model)(nil))
 	require.NoError(t, err)
 
-	in := &Model{Time: time.Unix(0, 12345678912345)}
+	in := &Model{
+		Time:       time.Unix(0, 12345678912345),
+		TimeWithTZ: time.Unix(0, 12345678912345).In(time.UTC),
+	}
 	_, err = db.NewInsert().Model(in).Exec(ctx)
 	require.NoError(t, err)
 
@@ -286,6 +290,7 @@ func TestDateTime64(t *testing.T) {
 	err = db.NewSelect().Model(out).Scan(ctx)
 	require.NoError(t, err)
 	require.Equal(t, in.Time.UnixNano(), out.Time.UnixNano())
+	require.Equal(t, in.TimeWithTZ.UnixNano(), out.TimeWithTZ.UnixNano())
 }
 
 func TestInvalidType(t *testing.T) {


### PR DESCRIPTION
`DateTime64` can have timezone. If the column defined with the timezone for example `DateTime64(3, 'UTC')`, When query try to parse value, the precision will always return as 0 because it errors.

In the `parseDateTime64Prec` function, when it passed `chSubType(s, "DateTime64(")` will got the value like `"3, 'UTC"` and will always errors when parse string to integer.

So we need to split by comma and take the first part to get the precision before convert to integer.


